### PR TITLE
Stringify schema errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default function (babel) {
   }
 
   if (schema.errors) {
-    throw new Error(schema.errors)
+    throw new Error(JSON.stringify(schema.errors))
   }
 
   if (schema.data) {


### PR DESCRIPTION
When using this plugin with create-react-app and a schema error comes
back from the GraphQL server, the error is represented as "[Object
object]", which is not useful at all. This simply adds a JSON.stringify
to the error message so that the errors are an opaque string.